### PR TITLE
google 認証時のuseEffect周りで起きていたエラーの解消

### DIFF
--- a/react_training_ryu_SPA_sample/src/hocks/AuthUser.ts
+++ b/react_training_ryu_SPA_sample/src/hocks/AuthUser.ts
@@ -9,7 +9,6 @@ import {
 
 import { userType } from "../types/userType";
 import { AuthUserContainer } from "../provider/AuthUserProvider";
-import { useEffect } from "react";
 
 export const useAuthUser = () => {
   const { setUser, setisLoggined, setisAuthChecked } =
@@ -28,12 +27,8 @@ export const useAuthUser = () => {
     await signOut(auth);
   };
 
-  useEffect(() => {
-    changeUserState();
-    setisAuthChecked(true);
-  }, []);
-
   const changeUserState = async () => {
+    setisAuthChecked(false);
     await onAuthStateChanged(auth, (getAuthUser: User | null) => {
       if (getAuthUser) {
         const current_User: userType = {
@@ -54,6 +49,7 @@ export const useAuthUser = () => {
         setUser(current_User);
         setisLoggined(false);
       }
+      setisAuthChecked(true);
     });
   };
 

--- a/react_training_ryu_SPA_sample/src/router/RouteAuthGate.tsx
+++ b/react_training_ryu_SPA_sample/src/router/RouteAuthGate.tsx
@@ -9,8 +9,8 @@ type Props = {
 
 export const RouteAuthGate = (props: Props) => {
   const { component, redirect } = props;
-  const { isLoggined } = AuthUserContainer.useContainer();
-
+  const { isLoggined, isAuthChecked } = AuthUserContainer.useContainer();
+  if (!isAuthChecked) return <p>認証チェック中</p>;
   if (!isLoggined) {
     return (
       <Navigate to={redirect} state={{ from: useLocation() }} replace={false} />

--- a/react_training_ryu_SPA_sample/src/router/RouterConfig.tsx
+++ b/react_training_ryu_SPA_sample/src/router/RouterConfig.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
-import { SampleDBContainer } from "../provider/SampleDBProvider";
 import { AboutPage } from "../views/AboutPage";
 import { HomePage } from "../views/HomePage";
 import { ItemLayout } from "../views/ItemLayout";

--- a/react_training_ryu_SPA_sample/src/views/Layout.tsx
+++ b/react_training_ryu_SPA_sample/src/views/Layout.tsx
@@ -1,7 +1,12 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Link, Outlet } from "react-router-dom";
+import { useAuthUser } from "../hocks/AuthUser";
 
 export const Layout = () => {
+  const { changeUserState } = useAuthUser();
+  useEffect(() => {
+    changeUserState();
+  }, []);
   return (
     <>
       <div>layout</div>


### PR DESCRIPTION
## チケットへのリンク
* https://example.com
## やったこと
* Warning: React has detected a change in the order of Hooks called by *. This will lead to bugs and errors if not fixed. For more information, read the Rules of Hooks: https://reactjs.org/link/rules-of-hooksの原因調査
* 認証済みだが、画面リロードした際に未認証になる問題の解決
## やらないこと
* routerの調整
## 何ができるようになるのか？（あれば。無いなら「無し」でOK）
認証画面で認証時に画面をリロードしても画面を保持する問題の解決
* なし
## 動作確認
* ローカルで確認（認証画面でのリロード）
## その他
* エラーの問題で考えられることuseEffectのStrictモードでは、一回目と二回目で処理が変わるとエラーが吐かれる
* 非同期処理ではしばしば一回目と二回目で処理が変わってしまうため、一度処理を止める必要がある

## 影響する機能
* RouteAuthGate
