### PR TITLE
イベント編集・ユーザー情報取得・個別イベント取得・コメント作成・コメント取得 のapiの連携

### DIFF
--- a/react_china/reacr-typescript-firebase-router-with-jserver/src/components/organisms/EventCreateEditForm.tsx
+++ b/react_china/reacr-typescript-firebase-router-with-jserver/src/components/organisms/EventCreateEditForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, ChangeEvent, FC } from "react";
+import React, { useState, ChangeEvent, FC, useEffect } from "react";
 import axios from "axios";
 import { useForm, SubmitHandler } from "react-hook-form";
 
@@ -13,10 +13,10 @@ type Props = {
 };
 
 export const EventCreateEditForm: FC<Props> = (props) => {
-  const { event, method } = props;
-
   const { loginUser } = useLoginUserContext();
   const { allTags } = useAllTagsContext();
+
+  const { event, method } = props;
 
   const { eventCreateEditDelete } = useEventCreateEditDelete();
 
@@ -30,8 +30,10 @@ export const EventCreateEditForm: FC<Props> = (props) => {
     formState: { errors },
   } = useForm<Event>();
 
-  setValue("user_id", loginUser?.uid);
-  if (event) setValue("event_id", event?.event_id);
+  useEffect(() => {
+    setValue("user_id", loginUser?.uid);
+    setValue("event_id", event?.event_id);
+  }, [event, loginUser]);
 
   const onSubmit: SubmitHandler<Event> = async (data: Event) => {
     console.log("onSubmit", data);
@@ -60,7 +62,9 @@ export const EventCreateEditForm: FC<Props> = (props) => {
   const onClickImageUp = async () => {
     console.log(tmpFile);
     try {
-      const res = await axios.get("http://localhost:5000/image");
+      const res = await axios.get(
+        "https://icy-mushroom-0e274e110.1.azurestaticapps.net/api/upload_image/"
+      );
       const icon_data = res.data;
       setValue("event_image", icon_data?.url);
     } catch {

--- a/react_china/reacr-typescript-firebase-router-with-jserver/src/components/organisms/EventDetail.tsx
+++ b/react_china/reacr-typescript-firebase-router-with-jserver/src/components/organisms/EventDetail.tsx
@@ -35,8 +35,14 @@ export const EventDetail: FC<Props> = (props) => {
     }
   }, [loginUser, event_id]);
 
+  // 個別イベントの取得
   const { getEvent, event } = useEvent();
-  useEffect(() => getEvent(event_id), []);
+  useEffect(() => {
+    getEvent(event_id);
+  }, []);
+
+  // ゲストのIDを配列化
+  const gusetsID = event?.event_guests?.map((gusets) => gusets?.user_id);
 
   const navigate = useNavigate();
 
@@ -63,6 +69,12 @@ export const EventDetail: FC<Props> = (props) => {
     await eventApply("post", applyEvent);
   };
 
+  // イベント参加登録解除ボタン
+  const onClickApplyCancel = async () => {
+    console.log(applyEvent);
+    await eventApply("delete", applyEvent);
+  };
+
   return (
     <>
       {loginUser?.uid === event?.event_owner?.user_id ? (
@@ -75,7 +87,13 @@ export const EventDetail: FC<Props> = (props) => {
           </button>
         </>
       ) : (
-        ""
+        <>
+          {gusetsID?.includes(loginUser?.uid) ?? (
+            <>
+              <button onClick={onClickApplyCancel}>参加登録解除</button>
+            </>
+          )}
+        </>
       )}
       <p>応募締め切り</p>
       <img src={event?.event_image} alt="イベントヘッダー画像" />
@@ -124,8 +142,8 @@ export const EventDetail: FC<Props> = (props) => {
             </>
           ))}
         </div>
+        <button onClick={onClickApply}>参加登録</button>
       </div>
-      <button onClick={onClickApply}>参加登録</button>
     </>
   );
 };

--- a/react_china/reacr-typescript-firebase-router-with-jserver/src/components/organisms/comment/Comment.tsx
+++ b/react_china/reacr-typescript-firebase-router-with-jserver/src/components/organisms/comment/Comment.tsx
@@ -8,7 +8,7 @@ type Props = {
 export const Comment: FC<Props> = (props) => {
   const { getComments, comments } = useComments();
   const { event_id } = props;
-  useEffect(() => getComments(event_id), []);
+  useEffect(() => getComments(event_id), [comments]);
   return (
     <>
       <div>

--- a/react_china/reacr-typescript-firebase-router-with-jserver/src/components/organisms/user/MyEventCatd.tsx
+++ b/react_china/reacr-typescript-firebase-router-with-jserver/src/components/organisms/user/MyEventCatd.tsx
@@ -15,7 +15,7 @@ export const MyEventCard: FC<Props> = (props) => {
 
   return (
     <>
-      <Link to={url}>
+      <Link to={url} state={{ event_id: event?.event_id }}>
         <p>あと{event?.event_left_date}日</p>
         <img src={event?.event_image} alt="イベント画像" />
         <p>{event?.event_created_date}</p>

--- a/react_china/reacr-typescript-firebase-router-with-jserver/src/components/pages/auth/EventEdit.tsx
+++ b/react_china/reacr-typescript-firebase-router-with-jserver/src/components/pages/auth/EventEdit.tsx
@@ -5,9 +5,15 @@ import { Event } from "../../../types/api/Event";
 
 import { EventCreateEditForm } from "../../organisms/EventCreateEditForm";
 
+type State = {
+  event: Event;
+};
+
 export const EventEdit: FC = () => {
   const location = useLocation();
-  const event: Event = location.state as Event;
+  const state = location.state as State;
+  const { event } = state;
+
   console.log(event);
 
   return (

--- a/react_china/reacr-typescript-firebase-router-with-jserver/src/hooks/api/get/useComment.ts
+++ b/react_china/reacr-typescript-firebase-router-with-jserver/src/hooks/api/get/useComment.ts
@@ -3,6 +3,10 @@ import axios from "axios";
 
 import { Comment } from "../../../types/api/Comment";
 
+type CommentApi = {
+  comments: Comment[];
+};
+
 export const useComments = () => {
   const [comments, setComments] = useState<Comment[]>();
 
@@ -10,8 +14,8 @@ export const useComments = () => {
     (async () => {
       const commentUrl = `https://icy-mushroom-0e274e110.1.azurestaticapps.net/api/comments?eventid=${event_id}`;
       try {
-        const res = await axios.get<Comment[]>(commentUrl);
-        setComments(res.data);
+        const res = await axios.get<CommentApi>(commentUrl);
+        setComments(res.data.comments);
       } catch (error) {
         console.log("コメントが取得できません。");
       }

--- a/react_china/reacr-typescript-firebase-router-with-jserver/src/hooks/api/postPutDelete/useCommentCreate.ts
+++ b/react_china/reacr-typescript-firebase-router-with-jserver/src/hooks/api/postPutDelete/useCommentCreate.ts
@@ -4,7 +4,7 @@ import { CommentPost } from "../../../types/react-hook-form/CommentPost";
 
 export const useCommentCreate = () => {
   const url =
-    "https://icy-mushroom-0e274e110.1.azurestaticapps.net/api/comment";
+    "https://icy-mushroom-0e274e110.1.azurestaticapps.net/api/comments";
   const commentCreate = async (obj: CommentPost) => {
     try {
       await axios.post(url, obj);


### PR DESCRIPTION
## チケットへのリンク
* なし
## やったこと
* イベント編集・ユーザー情報取得・個別イベント取得・コメント作成・コメント取得 以上のapiの連携
## やらないこと
* 残りの連携apiは　イベント検索・イベント参加登録・登録解除・画像アップ・ユーザー情報編集・イベント削除の6つ
## できるようになること（ユーザ目線）
* 連携したapiを画面から操作
## できなくなること（ユーザ目線）
* なし
## 動作確認
* api：azure functions　フロント：ローカル　での動作確認　
## その他
* なし
## 影響する機能
* なし
